### PR TITLE
Replace processor with callbacks

### DIFF
--- a/maestro-client/src/main/java/org/maestro/client/Maestro.java
+++ b/maestro-client/src/main/java/org/maestro/client/Maestro.java
@@ -16,6 +16,7 @@
 
 package org.maestro.client;
 
+import org.maestro.client.exchange.MaestroCollector;
 import org.maestro.client.exchange.MaestroCollectorExecutor;
 import org.maestro.client.exchange.MaestroMqttClient;
 import org.maestro.client.exchange.MaestroTopics;
@@ -587,5 +588,9 @@ public final class Maestro implements MaestroRequester {
         } while (retries > 0);
 
         return replies;
+    }
+
+    public MaestroCollector getCollector() {
+        return collectorExecutor.getCollector();
     }
 }

--- a/maestro-client/src/main/java/org/maestro/client/callback/MaestroNoteCallback.java
+++ b/maestro-client/src/main/java/org/maestro/client/callback/MaestroNoteCallback.java
@@ -1,0 +1,15 @@
+package org.maestro.client.callback;
+
+import org.maestro.common.client.notes.MaestroNote;
+
+/**
+ * A callback executed when a note is received
+ */
+public interface MaestroNoteCallback {
+
+    /**
+     * Executes the call back
+     * @param note the related note
+     */
+    void call(MaestroNote note);
+}

--- a/maestro-client/src/main/java/org/maestro/client/exchange/MaestroCollector.java
+++ b/maestro-client/src/main/java/org/maestro/client/exchange/MaestroCollector.java
@@ -16,6 +16,7 @@
 
 package org.maestro.client.exchange;
 
+import org.maestro.client.callback.MaestroNoteCallback;
 import org.maestro.common.client.notes.MaestroNote;
 import org.maestro.common.exceptions.MaestroConnectionException;
 import org.slf4j.Logger;
@@ -31,6 +32,7 @@ public class MaestroCollector extends AbstractMaestroPeer<MaestroNote> {
     private boolean running = true;
 
     private final List<MaestroNote> collected = Collections.synchronizedList(new LinkedList<MaestroNote>());
+    private final List<MaestroNoteCallback> callbacks = new LinkedList<>();
 
     public MaestroCollector(final String url) throws MaestroConnectionException {
         super(url, "maestro-java-collector",MaestroDeserializer::deserialize);
@@ -39,6 +41,10 @@ public class MaestroCollector extends AbstractMaestroPeer<MaestroNote> {
 
     @Override
     protected void noteArrived(MaestroNote note) {
+        for (MaestroNoteCallback callback : callbacks) {
+            callback.call(note);
+        }
+
         collected.add(note);
     }
 
@@ -61,4 +67,7 @@ public class MaestroCollector extends AbstractMaestroPeer<MaestroNote> {
         return ret;
     }
 
+    public List<MaestroNoteCallback> getCallbacks() {
+        return callbacks;
+    }
 }

--- a/maestro-client/src/main/java/org/maestro/client/exchange/MaestroCollectorExecutor.java
+++ b/maestro-client/src/main/java/org/maestro/client/exchange/MaestroCollectorExecutor.java
@@ -62,4 +62,8 @@ public class MaestroCollectorExecutor extends AbstractMaestroExecutor {
 
         maestroCollector.setRunning(false);
     }
+
+    public MaestroCollector getCollector() {
+        return (MaestroCollector) getMaestroPeer();
+    }
 }

--- a/maestro-common/src/main/java/org/maestro/common/worker/ThroughputStats.java
+++ b/maestro-common/src/main/java/org/maestro/common/worker/ThroughputStats.java
@@ -45,6 +45,10 @@ public class ThroughputStats implements PerfStats {
     }
 
     public double getRate() {
+        if (duration.getSeconds() == 0) {
+            return 0;
+        }
+
         return count / duration.getSeconds();
     }
 

--- a/maestro-test-scripts/src/main/groovy/singlepoint/ShortTestCount.groovy
+++ b/maestro-test-scripts/src/main/groovy/singlepoint/ShortTestCount.groovy
@@ -87,18 +87,24 @@ class ShortTestExecutorCount implements TestExecutor {
      */
     class ShortTestProcessor extends MaestroNoteProcessor {
         @Override
-        protected void processPingResponse(PingResponse note) {
+        protected boolean processPingResponse(PingResponse note) {
             println  "Elapsed time from " + note.getName() + ": " + note.getElapsed() + " ms"
+
+            return true;
         }
 
         @Override
-        protected void processNotifySuccess(TestSuccessfulNotification note) {
+        protected boolean processNotifySuccess(TestSuccessfulNotification note) {
             println "Test successful on " + note.getName()
+
+            return true;
         }
 
         @Override
-        protected void processNotifyFail(TestFailedNotification note) {
+        protected boolean processNotifyFail(TestFailedNotification note) {
             println "Test failed on " + note.getName()
+
+            return true;
         }
 
 

--- a/maestro-test-scripts/src/main/groovy/singlepoint/ShortTestDuration.groovy
+++ b/maestro-test-scripts/src/main/groovy/singlepoint/ShortTestDuration.groovy
@@ -91,18 +91,21 @@ class ShortTestExecutorDuration implements TestExecutor {
      */
     class ShortTestProcessor extends MaestroNoteProcessor {
         @Override
-        protected void processPingResponse(PingResponse note) {
+        protected boolean processPingResponse(PingResponse note) {
             println  "Elapsed time from " + note.getName() + ": " + note.getElapsed() + " ms"
+            return true;
         }
 
         @Override
-        protected void processNotifySuccess(TestSuccessfulNotification note) {
+        protected boolean processNotifySuccess(TestSuccessfulNotification note) {
             println "Test successful on " + note.getName()
+            return true;
         }
 
         @Override
-        protected void processNotifyFail(TestFailedNotification note) {
+        protected boolean processNotifyFail(TestFailedNotification note) {
             println "Test failed on " + note.getName()
+            return true;
         }
 
 

--- a/maestro-tests/src/main/java/org/maestro/tests/AbstractTestExecutor.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/AbstractTestExecutor.java
@@ -76,6 +76,16 @@ public abstract class AbstractTestExecutor implements TestExecutor {
     }
 
     /**
+     * Stop connected peers
+     * @throws MaestroConnectionException
+     */
+    protected void stopServices() throws MaestroConnectionException {
+        maestro.stopSender();
+        maestro.stopReceiver();
+        maestro.stopInspector();
+    }
+
+    /**
      * Try to guess the number of connected peers
      * @return the number of connected peers (best guess)
      * @throws MaestroConnectionException

--- a/maestro-tests/src/main/java/org/maestro/tests/AbstractTestProcessor.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/AbstractTestProcessor.java
@@ -120,7 +120,7 @@ public abstract class AbstractTestProcessor extends MaestroNoteProcessor {
     }
 
     @Override
-    protected boolean processNotifySuccess(final TestSuccessfulNotification note) {
+    public boolean processNotifySuccess(final TestSuccessfulNotification note) {
         logger.info("Test successful on {} after {} executions", note.getName(),
                 testProfile.getTestExecutionNumber());
         logger.info("Test parameters used: {}", testProfile.toString());
@@ -136,7 +136,7 @@ public abstract class AbstractTestProcessor extends MaestroNoteProcessor {
     }
 
     @Override
-    protected boolean processNotifyFail(TestFailedNotification note) {
+    public boolean processNotifyFail(TestFailedNotification note) {
         logger.info("Test failed on {} after {} executions", note.getName(),
                 testProfile.getTestExecutionNumber());
 

--- a/maestro-tests/src/main/java/org/maestro/tests/flex/FlexibleTestProcessor.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/flex/FlexibleTestProcessor.java
@@ -33,7 +33,7 @@ public class FlexibleTestProcessor extends AbstractTestProcessor {
     }
 
     @Override
-    protected boolean processNotifyFail(TestFailedNotification note) {
+    public boolean processNotifyFail(TestFailedNotification note) {
         super.processNotifyFail(note);
         successful = false;
         return true;


### PR DESCRIPTION
Basically this re-implements the fixed rate test with a callbacks-based API that allow the test to react proactively to situations when the rate is too low in the warm up. This would lead to very long warm up times, test request overruns, etc. 
Now, the fixed rate test evaluates the current rate and decides whether to stop the warm up based on either the test reaching the warm-up ceiling count or exhausting the maximum run time period.