### PR TITLE
FIX: NPE reported to the logs if receiver failed.

### DIFF
--- a/maestro-client/src/main/java/org/maestro/client/exchange/MaestroCollectorExecutor.java
+++ b/maestro-client/src/main/java/org/maestro/client/exchange/MaestroCollectorExecutor.java
@@ -40,8 +40,7 @@ public class MaestroCollectorExecutor extends AbstractMaestroExecutor {
 
         logger.trace("Created a new maestro collector executor");
 
-        getMaestroPeer().connect();
-        getMaestroPeer().subscribe(MaestroTopics.MAESTRO_TOPICS);
+        super.start(MaestroTopics.MAESTRO_TOPICS);
     }
 
 


### PR DESCRIPTION
By doing the self initialization of the connection, the MaestroCollectorExecutor, which is used by the client only, does not retain the subscribed topics. This leads to a NPE when the broker goes down the client tries to reconnect.