### PR TITLE
UPD: enforce a limit to how long it can wait for all the workers to stop

### DIFF
--- a/extra/docker-compose/maestro/Makefile
+++ b/extra/docker-compose/maestro/Makefile
@@ -1,5 +1,5 @@
 MAESTRO_VERSION=1.4.0-SNAPSHOT
-MAESTRO_BRANCH=maestro-java-1.4.0-SNAPSHOT
+MAESTRO_BRANCH=devel
 
 .PHONY: broker clean all client exporter
 

--- a/maestro-worker/src/main/resources/config/maestro-worker.properties
+++ b/maestro-worker/src/main/resources/config/maestro-worker.properties
@@ -48,10 +48,15 @@
 # the clients can consume the messages faster. This delay is in milliseconds.
 # maestro.worker.throttle.delay=500
 
-# How much time it will wait for each worker to complete its unit of work after processing and event
-# that results in test stop
+# How much time it will wait for each worker to complete its unit of work after processing an event
+# that results in test stop or the test is complete (in milliseconds)
 # maestro.worker.stop.timeout=1000
 
 
 # How many tries the workers have until they consider a queue as drained.
 #worker.auto.drain.retries=10
+
+
+# The maximum combined amount of time for all the workers to complete their unit of work after processing
+# an event that results in test stop or the test is complete (in milliseconds)
+# maestro.worker.active.deadline.max=55000


### PR DESCRIPTION
The maximum deadline for large scale testing can be too much sometimes. This patch adds a limit to how much it can wait for that.

Obs.: saving it for another build. It needs more review/testing.