### PR TITLE
NEW: drain support

### DIFF
--- a/maestro-agent/src/main/java/org/maestro/agent/base/AgentConstants.java
+++ b/maestro-agent/src/main/java/org/maestro/agent/base/AgentConstants.java
@@ -71,4 +71,6 @@ class AgentConstants {
     static final String PROTOCOL_ERROR = "protocolerror";
 
     static final String INTERNAL_ERROR = "internalerror";
+
+    static final String DRAIN = "drain";
 }

--- a/maestro-agent/src/main/java/org/maestro/agent/base/MaestroAgent.java
+++ b/maestro-agent/src/main/java/org/maestro/agent/base/MaestroAgent.java
@@ -388,4 +388,9 @@ public class MaestroAgent extends MaestroWorkerManager implements MaestroAgentEv
             logger.warn("The log directory for the agent does not exist");
         }
     }
+
+    @Override
+    public void handle(DrainRequest note) {
+        extensionPoints.forEach(point -> callbacksWrapper(point.getPath(), AgentConstants.DRAIN, note));
+    }
 }

--- a/maestro-client/src/main/java/org/maestro/client/Maestro.java
+++ b/maestro-client/src/main/java/org/maestro/client/Maestro.java
@@ -520,6 +520,16 @@ public final class Maestro implements MaestroRequester {
         maestroClient.publish(topic, maestroNote);
     }
 
+    public void drainRequest(final String topic, final String duration, final String url, int parallelCount) {
+        DrainRequest drainRequest = new DrainRequest();
+
+        drainRequest.setDuration(duration);
+        drainRequest.setUrl(url);
+        drainRequest.setParallelCount(String.valueOf(parallelCount));
+
+        maestroClient.publish(topic, drainRequest);
+    }
+
     /**
      * Collect replies
      * @return A list of serialized maestro replies

--- a/maestro-client/src/main/java/org/maestro/client/MaestroReceiverClient.java
+++ b/maestro-client/src/main/java/org/maestro/client/MaestroReceiverClient.java
@@ -27,7 +27,6 @@ import org.maestro.common.client.MaestroReceiver;
 import org.maestro.common.client.notes.MaestroNote;
 import org.maestro.common.duration.EpochClocks;
 import org.maestro.common.duration.EpochMicroClock;
-import org.maestro.common.exceptions.MaestroException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,5 +206,22 @@ public class MaestroReceiverClient extends MaestroMqttClient implements MaestroR
         ThrottleCallback throttleCallback = new ThrottleCallback();
 
         super.publish(MaestroTopics.MAESTRO_LOGS_TOPIC, logResponse, 0, false, throttleCallback);
+    }
+
+
+    public void notifyDrainComplete(final String message) {
+        logger.trace("Sending the drain complete notification from {}", this.toString());
+        DrainCompleteNotification notification = new DrainCompleteNotification();
+
+        notification.setName(clientName + "@" + host);
+        notification.setId(id);
+
+        notification.setMessage(message);
+
+        try {
+            super.publish(MaestroTopics.NOTIFICATION_TOPIC, notification, 0, true);
+        } catch (Exception e) {
+            logger.error("Unable to publish the drain complete notification: {}", e.getMessage(), e);
+        }
     }
 }

--- a/maestro-client/src/main/java/org/maestro/client/exchange/MaestroDeserializer.java
+++ b/maestro-client/src/main/java/org/maestro/client/exchange/MaestroDeserializer.java
@@ -47,9 +47,12 @@ public class MaestroDeserializer {
             case MAESTRO_NOTE_ABNORMAL_DISCONNECT: {
                 return new AbnormalDisconnect(unpacker);
             }
+            case MAESTRO_NOTE_NOTIFY_DRAIN_COMPLETE: {
+                return new DrainCompleteNotification(unpacker);
+            }
             default: {
                 throw new MalformedNoteException("Invalid notification command: " + tmpCommand);
-            }
+           }
         }
     }
 
@@ -160,6 +163,9 @@ public class MaestroDeserializer {
             }
             case MAESTRO_NOTE_LOG: {
                 return new LogRequest(unpacker);
+            }
+            case MAESTRO_NOTE_DRAIN: {
+                return new DrainRequest(unpacker);
             }
             default: {
                 throw new MalformedNoteException("Invalid request command: " + tmpCommand);

--- a/maestro-client/src/main/java/org/maestro/client/notes/DrainCompleteNotification.java
+++ b/maestro-client/src/main/java/org/maestro/client/notes/DrainCompleteNotification.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Otavio R. Piske <angusyoung@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.maestro.client.notes;
+
+import org.maestro.common.client.notes.MaestroCommand;
+import org.msgpack.core.MessageBufferPacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.IOException;
+
+public class DrainCompleteNotification extends MaestroNotification {
+    private String message;
+
+    public DrainCompleteNotification() {
+        super(MaestroCommand.MAESTRO_NOTE_NOTIFY_DRAIN_COMPLETE);
+    }
+
+    public DrainCompleteNotification(MessageUnpacker unpacker) throws IOException {
+        super(MaestroCommand.MAESTRO_NOTE_NOTIFY_DRAIN_COMPLETE, unpacker);
+
+        message = unpacker.unpackString();
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public void notify(MaestroEventListener visitor) {
+        visitor.handle(this);
+    }
+
+    @Override
+    protected MessageBufferPacker pack() throws IOException {
+        MessageBufferPacker packer = super.pack();
+
+        packer.packString(message);
+
+        return packer;
+    }
+
+    @Override
+    public String toString() {
+        return "TestFailedNotification{" +
+                "message='" + message + '\'' +
+                "} " + super.toString();
+    }
+}

--- a/maestro-client/src/main/java/org/maestro/client/notes/DrainRequest.java
+++ b/maestro-client/src/main/java/org/maestro/client/notes/DrainRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Otavio R. Piske <angusyoung@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.maestro.client.notes;
+
+import org.maestro.common.client.notes.MaestroCommand;
+import org.msgpack.core.MessageBufferPacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.IOException;
+
+
+public class DrainRequest extends MaestroRequest<MaestroReceiverEventListener> {
+    private String duration;
+    private String url;
+    private String parallelCount;
+
+    public DrainRequest() {
+        super(MaestroCommand.MAESTRO_NOTE_DRAIN);
+    }
+
+    public DrainRequest(final MessageUnpacker unpacker) throws IOException {
+        super(MaestroCommand.MAESTRO_NOTE_DRAIN);
+
+        this.duration = unpacker.unpackString();
+        this.url = unpacker.unpackString();
+        this.parallelCount = unpacker.unpackString();
+    }
+
+    public String getDuration() {
+        return duration;
+    }
+
+    public void setDuration(String duration) {
+        this.duration = duration;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getParallelCount() {
+        return parallelCount;
+    }
+
+    public void setParallelCount(String parallelCount) {
+        this.parallelCount = parallelCount;
+    }
+
+    @Override
+    public void notify(MaestroReceiverEventListener visitor) {
+        visitor.handle(this);
+    }
+
+    @Override
+    protected MessageBufferPacker pack() throws IOException {
+        MessageBufferPacker packer = super.pack();
+
+        packer.packString(this.duration);
+        packer.packString(this.url);
+        packer.packString(this.parallelCount);
+
+        return packer;
+    }
+
+
+    @Override
+    public String toString() {
+        return "DrainRequest{" +
+                "duration='" + duration + '\'' +
+                ", url='" + url + '\'' +
+                ", parallelCount=" + parallelCount +
+                "} " + super.toString();
+    }
+}

--- a/maestro-client/src/main/java/org/maestro/client/notes/MaestroEventListener.java
+++ b/maestro-client/src/main/java/org/maestro/client/notes/MaestroEventListener.java
@@ -43,4 +43,6 @@ public interface MaestroEventListener {
 
     void handle(LogRequest note);
 
+    void handle(DrainCompleteNotification note);
+
 }

--- a/maestro-common/src/main/java/org/maestro/common/client/notes/MaestroCommand.java
+++ b/maestro-common/src/main/java/org/maestro/common/client/notes/MaestroCommand.java
@@ -52,7 +52,9 @@ public enum MaestroCommand {
     MAESTRO_NOTE_STOP_AGENT(19),
     MAESTRO_NOTE_AGENT_SOURCE(21),
     MAESTRO_NOTE_USER_COMMAND_1(30),
-    MAESTRO_NOTE_LOG(40);
+    MAESTRO_NOTE_LOG(40),
+    MAESTRO_NOTE_DRAIN(41),
+    MAESTRO_NOTE_NOTIFY_DRAIN_COMPLETE(42);
 
     private final long value;
 
@@ -89,6 +91,8 @@ public enum MaestroCommand {
             case 21: return MAESTRO_NOTE_AGENT_SOURCE;
             case 30: return MAESTRO_NOTE_USER_COMMAND_1;
             case 40: return MAESTRO_NOTE_LOG;
+            case 41: return MAESTRO_NOTE_DRAIN;
+            case 42: return MAESTRO_NOTE_NOTIFY_DRAIN_COMPLETE;
             default: {
                 Logger logger = LoggerFactory.getLogger(MaestroCommand.class);
                 logger.error("The command {} is not implemented. This is a bug in Maestro", value);

--- a/maestro-common/src/main/java/org/maestro/common/duration/DurationDrain.java
+++ b/maestro-common/src/main/java/org/maestro/common/duration/DurationDrain.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Otavio R. Piske <angusyoung@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.maestro.common.duration;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.maestro.common.ConfigurationWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DurationDrain extends DurationCount {
+    public static final String DURATION_DRAIN_FORMAT = "-1";
+
+    private static final Logger logger = LoggerFactory.getLogger(DurationDrain.class);
+    private static final AbstractConfiguration config = ConfigurationWrapper.getConfig();
+
+
+    private final int drainRetries;
+    private long lastCount = 0;
+    private long repeat = 0;
+
+    public DurationDrain() {
+        super(-1);
+
+        drainRetries = config.getInt("worker.auto.drain.retries", 10);
+    }
+
+    @Override
+    public boolean canContinue(TestProgress progress) {
+        long count = progress.messageCount();
+
+        if (count > lastCount) {
+            lastCount = count;
+        }
+        else {
+            if (count == lastCount) {
+                repeat++;
+                logger.info("Apparently no more data is in the queue ... retrying for 10 more times");
+
+                if (repeat >= drainRetries) {
+                    logger.info("Exhausted the retries, aborting the drain");
+
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/maestro-common/src/main/java/org/maestro/common/duration/TestDurationBuilder.java
+++ b/maestro-common/src/main/java/org/maestro/common/duration/TestDurationBuilder.java
@@ -40,6 +40,10 @@ public class TestDurationBuilder {
             return new DurationTime(durationSpec);
         }
         else {
+            if (durationSpec.equals(DurationDrain.DURATION_DRAIN_FORMAT)) {
+                return new DurationDrain();
+            }
+
             return new DurationCount(durationSpec);
         }
     }

--- a/maestro-common/src/main/java/org/maestro/common/io/data/readers/BinaryRateReader.java
+++ b/maestro-common/src/main/java/org/maestro/common/io/data/readers/BinaryRateReader.java
@@ -15,7 +15,7 @@ public class BinaryRateReader implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(BinaryRateReader.class);
 
     private FileChannel fileChannel;
-    private ByteBuffer byteBuffer = ByteBuffer.allocate(FileHeader.BYTES + (RateEntry.BYTES * 20));
+    private ByteBuffer byteBuffer = ByteBuffer.allocateDirect(FileHeader.BYTES + (RateEntry.BYTES * 20));
 
     private final FileHeader fileHeader;
 

--- a/maestro-common/src/main/java/org/maestro/common/io/data/writers/BinaryRateUpdater.java
+++ b/maestro-common/src/main/java/org/maestro/common/io/data/writers/BinaryRateUpdater.java
@@ -43,7 +43,7 @@ public class BinaryRateUpdater implements AutoCloseable {
     private FileChannel fileChannel;
     private FileHeader fileHeader;
 
-    private ByteBuffer byteBuffer = ByteBuffer.allocate(FileHeader.BYTES + 2);
+    private ByteBuffer byteBuffer = ByteBuffer.allocateDirect(FileHeader.BYTES + 2);
     private boolean overlay;
 
     /**

--- a/maestro-common/src/main/java/org/maestro/common/io/data/writers/BinaryRateWriter.java
+++ b/maestro-common/src/main/java/org/maestro/common/io/data/writers/BinaryRateWriter.java
@@ -25,7 +25,7 @@ public class BinaryRateWriter implements RateWriter {
     private long last = 0;
 
     // TODO: size needs to be adjusted accordingly
-    private ByteBuffer byteBuffer = ByteBuffer.allocate(FileHeader.BYTES + (RateEntry.BYTES * 10));
+    private ByteBuffer byteBuffer = ByteBuffer.allocateDirect(FileHeader.BYTES + (RateEntry.BYTES * 10));
 
     /**
      * Constructor

--- a/maestro-common/src/main/java/org/maestro/common/worker/WorkerOptions.java
+++ b/maestro-common/src/main/java/org/maestro/common/worker/WorkerOptions.java
@@ -19,6 +19,7 @@ package org.maestro.common.worker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Represents the options set on the worker by the front-end
  */
@@ -33,6 +34,28 @@ public class WorkerOptions {
     private String throttle;
     private String rate;
     private String fcl;
+
+    public WorkerOptions() {
+    }
+
+    public WorkerOptions(final WorkerOptions workerOptions) {
+        this(workerOptions.getBrokerURL(), workerOptions.getDuration(), workerOptions.getLogLevel(),
+                workerOptions.getParallelCount(), workerOptions.getMessageSize(), workerOptions.getThrottle(),
+                workerOptions.getRate(), workerOptions.getFcl());
+    }
+
+    public WorkerOptions(final String brokerURL, final String duration, final String logLevel,
+                         final String parallelCount, final String messageSize, final String throttle,
+                         final String rate, final String fcl) {
+        this.brokerURL = brokerURL;
+        this.duration = duration;
+        this.logLevel = logLevel;
+        this.parallelCount = parallelCount;
+        this.messageSize = messageSize;
+        this.throttle = throttle;
+        this.rate = rate;
+        this.fcl = fcl;
+    }
 
     /**
      * Gets the broker URL
@@ -92,6 +115,17 @@ public class WorkerOptions {
      */
     public String getParallelCount() {
         return parallelCount;
+    }
+
+    public Integer getParallelCountAsInt() {
+        try {
+            return Integer.parseInt(getParallelCount());
+        }
+        catch (NumberFormatException e) {
+            logger.warn("Unable to parse the provided parallel count {}", getParallelCount());
+        }
+
+        return null;
     }
 
     /**

--- a/maestro-worker/src/main/resources/config/maestro-worker.properties
+++ b/maestro-worker/src/main/resources/config/maestro-worker.properties
@@ -51,3 +51,7 @@
 # How much time it will wait for each worker to complete its unit of work after processing and event
 # that results in test stop
 # maestro.worker.stop.timeout=1000
+
+
+# How many tries the workers have until they consider a queue as drained.
+#worker.auto.drain.retries=10

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/MaestroWorkerManager.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/MaestroWorkerManager.java
@@ -282,6 +282,11 @@ public abstract class MaestroWorkerManager extends AbstractMaestroPeer<MaestroEv
         }
     }
 
+    @Override
+    public void handle(DrainCompleteNotification note) {
+        // NO-OP
+    }
+
     /**
      * Handle a log request note
      * @param note the note to handle

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/WorkerContainer.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/WorkerContainer.java
@@ -20,100 +20,84 @@ import org.maestro.common.evaluators.Evaluator;
 import org.maestro.common.evaluators.LatencyEvaluator;
 import org.maestro.common.exceptions.MaestroException;
 import org.maestro.common.worker.*;
+import org.maestro.worker.common.container.initializers.WorkerInitializer;
+import org.maestro.worker.common.watchdog.WatchdogObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * This is a container class for multiple workerRuntimeInfos. It is responsible for
  * creating, starting and stopping multiple workerRuntimeInfos at once.
  */
 public final class WorkerContainer {
+
     private static WorkerContainer instance;
-    private WorkerOptions workerOptions;
     private final List<WorkerRuntimeInfo> workerRuntimeInfos = new ArrayList<>();
+    private final List<WatchdogObserver> observers = new LinkedList<>();
 
     private WorkerWatchdog workerWatchdog;
     private Thread watchDogThread;
     private LocalDateTime startTime;
     private Evaluator<?> evaluator;
 
-    private WorkerContainer() {
+    public WorkerContainer() {
     }
 
-    /**
-     * Gets and instance of the container
-     * @return the instance of the container
-     */
-    public synchronized static WorkerContainer getInstance() {
-        if (instance == null) {
-            instance = new WorkerContainer();
+
+    public List<MaestroWorker> create(final WorkerInitializer initializer, int count) throws IllegalAccessException, InstantiationException {
+        workerRuntimeInfos.clear();
+
+        List<MaestroWorker> workers = new ArrayList<>(count);
+
+        for (int i = 0; i < count; i++) {
+            final MaestroWorker worker = initializer.initialize(i);
+
+            workers.add(worker);
+
+            WorkerRuntimeInfo ri = new WorkerRuntimeInfo();
+
+            ri.worker = worker;
+            ri.thread = new Thread(ri.worker);
+            workerRuntimeInfos.add(ri);
         }
 
-        return instance;
-    }
-
-
-    /**
-     * Sets the worker options for the instance.
-     * @param workerOptions the worker options to set
-     */
-    public void setWorkerOptions(WorkerOptions workerOptions) {
-        this.workerOptions = workerOptions;
+        return workers;
     }
 
     /**
      * Start the execution of the workers for a predefined class
-     * @param clazz The class associated with the workers
-     * @param workers The collection to contain the workers
-     * @param onWorkersStopped callback that will be called when the workers will stop
      * @param evaluator The evaluator that is run along w/ the worker watchdog (ie.: to evaluate the FCL/latency)
      * @throws IllegalAccessException if unable to access the worker constructor
      * @throws InstantiationException if unable to instantiate the worker
      */
-    public void start(final Class<MaestroWorker> clazz, Collection<? super MaestroWorker> workers,
-                      Consumer<? super List<WorkerRuntimeInfo>> onWorkersStopped, Evaluator<?> evaluator)
-            throws IllegalAccessException, InstantiationException {
-        final int parallelCount = Integer.parseInt(workerOptions.getParallelCount());
-        this.workerRuntimeInfos.clear();
+    public void start(final Evaluator<?> evaluator) {
+
         this.evaluator = evaluator;
+
         try {
-            createAndStartWorkers(clazz, workerOptions, parallelCount, this.workerRuntimeInfos, onWorkersStopped, evaluator);
-        } catch (Throwable t) {
-            //interrupt any workers
-            this.workerRuntimeInfos.forEach(info -> info.thread.interrupt());
-            //cleanup
-            this.workerRuntimeInfos.clear();
+            for (WorkerRuntimeInfo workerRuntimeInfo : workerRuntimeInfos) {
+                workerRuntimeInfo.thread.start();
+            }
+
+            workerWatchdog = new WorkerWatchdog(this, workerRuntimeInfos, evaluator);
+
+            watchDogThread = new Thread(workerWatchdog);
+            watchDogThread.start();
+
+            startTime = LocalDateTime.now();
+
+        }
+        catch (Throwable t) {
+            workerRuntimeInfos.clear();
+
             throw t;
         }
-        //the workers are started
-        workers.addAll(this.workerRuntimeInfos.stream().map(info -> info.worker).collect(Collectors.toList()));
-        startTime = LocalDateTime.now();
-    }
-
-    private void createAndStartWorkers(final Class<MaestroWorker> clazz, WorkerOptions workerOptions, int workers,
-                                       List<WorkerRuntimeInfo> workerRuntimeInfos,
-                                       final Consumer<? super List<WorkerRuntimeInfo>> onWorkersStopped,
-                                       final Evaluator<?> evaluator) throws IllegalAccessException, InstantiationException {
-        for (int i = 0; i < workers; i++) {
-            final WorkerRuntimeInfo ri = new WorkerRuntimeInfo();
-            ri.worker = clazz.newInstance();
-            ri.worker.setWorkerOptions(workerOptions);
-            ri.worker.setWorkerNumber(i);
-            ri.thread = new Thread(ri.worker);
-            ri.thread.start();
-            workerRuntimeInfos.add(ri);
-        }
-
-        workerWatchdog = new WorkerWatchdog(workerRuntimeInfos, onWorkersStopped, evaluator);
-
-        watchDogThread = new Thread(workerWatchdog);
-        watchDogThread.start();
     }
 
     public void stop() {
@@ -224,5 +208,23 @@ public final class WorkerContainer {
         }
 
         return null;
+    }
+
+    public List<WatchdogObserver> getObservers() {
+        return observers;
+    }
+
+    public boolean waitForComplete(long timeout) {
+        try {
+            watchDogThread.join(timeout);
+
+            return watchDogThread.isAlive();
+        } catch (InterruptedException e) {
+            Logger logger = LoggerFactory.getLogger(WorkerContainer.class);
+
+            logger.debug("Interrupted while waiting for the watchdog to complete running");
+        }
+
+        return false;
     }
 }

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/container/initializers/TestWorkerInitializer.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/container/initializers/TestWorkerInitializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Otavio R. Piske <angusyoung@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.maestro.worker.common.container.initializers;
+
+import org.maestro.common.evaluators.Evaluator;
+import org.maestro.common.worker.MaestroWorker;
+import org.maestro.common.worker.WorkerOptions;
+
+public class TestWorkerInitializer implements WorkerInitializer {
+    private Class<MaestroWorker> clazz;
+    private Evaluator<?> evaluator;
+    private WorkerOptions workerOptions;
+
+    public TestWorkerInitializer(Class<MaestroWorker> clazz, Evaluator<?> evaluator, WorkerOptions workerOptions) {
+        this.clazz = clazz;
+        this.evaluator = evaluator;
+        this.workerOptions = workerOptions;
+    }
+
+    public Class<MaestroWorker> getClazz() {
+        return clazz;
+    }
+
+    public Evaluator<?> getEvaluator() {
+        return evaluator;
+    }
+
+    public WorkerOptions getWorkerOptions() {
+        return workerOptions;
+    }
+
+
+    @Override
+    public MaestroWorker initialize(int number) throws IllegalAccessException, InstantiationException {
+        final MaestroWorker worker = clazz.newInstance();
+
+        worker.setWorkerOptions(workerOptions);
+        worker.setWorkerNumber(number);
+
+        return worker;
+    }
+}

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/container/initializers/WorkerInitializer.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/container/initializers/WorkerInitializer.java
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package org.maestro.client.notes;
+package org.maestro.worker.common.container.initializers;
+
+import org.maestro.common.worker.MaestroWorker;
 
 
-/**
- * Visitor that handles receiver-specific {@link MaestroEvent} instances.
- */
-@SuppressWarnings("unused")
-public interface MaestroReceiverEventListener {
+public interface WorkerInitializer {
 
-    void handle(StartReceiver note);
-
-    void handle(StopReceiver note);
-
-    void handle(DrainRequest note);
+    MaestroWorker initialize(int number) throws IllegalAccessException, InstantiationException;
 }

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/CleanupObserver.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/CleanupObserver.java
@@ -1,0 +1,22 @@
+package org.maestro.worker.common.watchdog;
+
+import org.maestro.worker.common.WorkerRuntimeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Cleans up the list of workers and do any other cleanup required
+ */
+public class CleanupObserver implements WatchdogObserver {
+    private static final Logger logger = LoggerFactory.getLogger(CleanupObserver.class);
+
+    @Override
+    public boolean onStop(List<WorkerRuntimeInfo> workerRuntimeInfos) {
+        logger.info("Cleaning up the list of worker runtimes");
+
+        workerRuntimeInfos.clear();
+        return false;
+    }
+}

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/DrainObserver.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/DrainObserver.java
@@ -1,0 +1,56 @@
+package org.maestro.worker.common.watchdog;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.maestro.client.MaestroReceiverClient;
+import org.maestro.common.ConfigurationWrapper;
+import org.maestro.common.duration.DurationDrain;
+import org.maestro.common.worker.WorkerOptions;
+import org.maestro.worker.common.WorkerContainer;
+import org.maestro.worker.common.WorkerRuntimeInfo;
+import org.maestro.worker.common.container.initializers.WorkerInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DrainObserver implements WatchdogObserver {
+    private static final Logger logger = LoggerFactory.getLogger(DrainObserver.class);
+    private static final AbstractConfiguration config = ConfigurationWrapper.getConfig();
+
+    private final WorkerOptions workerOptions;
+    private final WorkerContainer workerContainer = new WorkerContainer();
+    private final WorkerInitializer workerInitializer;
+    private final MaestroReceiverClient client;
+
+    public DrainObserver(final WorkerOptions workerOptions, final WorkerInitializer workerInitializer,
+                         final MaestroReceiverClient client) {
+        this.workerOptions = new WorkerOptions(workerOptions);
+        this.workerOptions.setDuration(DurationDrain.DURATION_DRAIN_FORMAT);
+
+        this.workerInitializer = workerInitializer;
+        this.client = client;
+    }
+
+
+    @Override
+    public boolean onStop(List<WorkerRuntimeInfo> workerRuntimeInfos) {
+        final int drainRetries = (config.getInt("worker.auto.drain.retries", 10) + 5);
+
+        int count = workerOptions.getParallelCountAsInt();
+        try {
+            workerContainer.create(workerInitializer, count);
+
+            logger.info("Starting to drain the queues after the test was executed");
+            workerContainer.start(null);
+
+            workerContainer.waitForComplete(drainRetries * 1000);
+            logger.info("Drain completed successfully");
+            client.notifyDrainComplete("Drain completed successfully");
+        } catch (Throwable t) {
+            logger.error("Unable to start drain workers: {}", t.getMessage(), t);
+            client.notifyDrainComplete("Drain completed with warnings");
+        }
+
+        return true;
+    }
+}

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/LatencyWriterObserver.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/LatencyWriterObserver.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Otavio R. Piske <angusyoung@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.maestro.worker.common.watchdog;
+
+import org.maestro.common.exceptions.MaestroException;
+import org.maestro.worker.common.WorkerLatencyWriter;
+import org.maestro.worker.common.WorkerRuntimeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * An observer for the watchdog that handles the latency writing
+ * process based on the start/stop of the tests
+ */
+public class LatencyWriterObserver implements WatchdogObserver {
+    private static final Logger logger = LoggerFactory.getLogger(LatencyWriterObserver.class);
+    private final WorkerLatencyWriter latencyWriter;
+    private Thread latencyWriterThread;
+    private Thread shutdownThread;
+
+    public LatencyWriterObserver(final WorkerLatencyWriter latencyWriter) {
+        this.latencyWriter = latencyWriter;
+        shutdownThread = new Thread(this::shutdown);
+
+        Runtime.getRuntime().addShutdownHook(shutdownThread);
+    }
+
+    private void shutdown() {
+        if (latencyWriterThread != null) {
+            this.latencyWriterThread.interrupt();
+
+            try {
+                this.latencyWriterThread.join();
+            } catch (InterruptedException e) {
+                logger.error("Latency writer thread was interrupted: {}", e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
+    public boolean onStart() {
+        try {
+            this.latencyWriterThread = new Thread(latencyWriter);
+            latencyWriterThread.start();
+            return true;
+        }
+        catch (Throwable t) {
+            throw new MaestroException("Unable to start the latency writer", t);
+        }
+    }
+
+    @Override
+    public boolean onStop(final List<WorkerRuntimeInfo> workerRuntimeInfos) {
+        this.latencyWriterThread.interrupt();
+
+        try {
+            this.latencyWriterThread.join();
+        } catch (InterruptedException e) {
+            logger.error("Latency writer thread was interrupted: {}", e.getMessage(), e);
+        }
+        finally {
+            Runtime.getRuntime().removeShutdownHook(shutdownThread);
+        }
+
+        return true;
+    }
+}

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/RateWriterObserver.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/RateWriterObserver.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Otavio R. Piske <angusyoung@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.maestro.worker.common.watchdog;
+
+import org.maestro.common.exceptions.MaestroException;
+import org.maestro.worker.common.WorkerRateWriter;
+import org.maestro.worker.common.WorkerRuntimeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * An observer for the watchdog that handles the rate writing
+ * process based on the start/stop of the tests
+ */
+public class RateWriterObserver implements WatchdogObserver {
+    private static final Logger logger = LoggerFactory.getLogger(RateWriterObserver.class);
+    private final WorkerRateWriter workerRateWriter;
+    private Thread rateWriterThread;
+    private Thread shutdownThread;
+
+    public RateWriterObserver(final WorkerRateWriter workerRateWriter) {
+        this.workerRateWriter = workerRateWriter;
+
+        shutdownThread = new Thread(this::shutdown);
+        Runtime.getRuntime().addShutdownHook(shutdownThread);
+    }
+
+    private void shutdown() {
+        if (this.rateWriterThread != null) {
+            try {
+                this.rateWriterThread.join();
+            } catch (InterruptedException e) {
+                logger.error("Rate writer thread was interrupted: {}", e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
+    public boolean onStart() {
+        try {
+            rateWriterThread = new Thread(workerRateWriter);
+            rateWriterThread.start();
+        }
+        catch (Throwable t) {
+            throw new MaestroException("Unable to start rate writer", t);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean onStop(final List<WorkerRuntimeInfo> workerRuntimeInfos) {
+        this.rateWriterThread.interrupt();
+
+        try {
+            this.rateWriterThread.join();
+        } catch (InterruptedException e) {
+            logger.error("Rate writer thread was interrupted: {}", e.getMessage(), e);
+        }
+        finally {
+            Runtime.getRuntime().removeShutdownHook(shutdownThread);
+        }
+
+        return true;
+    }
+}

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/WatchdogObserver.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/WatchdogObserver.java
@@ -14,18 +14,33 @@
  * limitations under the License.
  */
 
-package org.maestro.client.notes;
+package org.maestro.worker.common.watchdog;
 
+import org.maestro.worker.common.WorkerRuntimeInfo;
+
+import java.util.List;
 
 /**
- * Visitor that handles receiver-specific {@link MaestroEvent} instances.
+ * Actions that are run when the watchdog change state. For now it handles only
+ * start and stop state changes
  */
-@SuppressWarnings("unused")
-public interface MaestroReceiverEventListener {
+public interface WatchdogObserver {
 
-    void handle(StartReceiver note);
+    /**
+     * Actions that run on watchdog start
+     * @return
+     */
+    default boolean onStart() {
+        return true;
+    }
 
-    void handle(StopReceiver note);
+    /**
+     * Actions that run on watchdog stop
+     * @param workerRuntimeInfos
+     * @return
+     */
+    default boolean onStop(final List<WorkerRuntimeInfo> workerRuntimeInfos) {
+        return true;
+    }
 
-    void handle(DrainRequest note);
 }

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/WorkerShutdownObserver.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/WorkerShutdownObserver.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 Otavio R. Piske <angusyoung@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.maestro.worker.common.watchdog;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.maestro.client.MaestroReceiverClient;
+import org.maestro.common.ConfigurationWrapper;
+import org.maestro.common.worker.TestLogUtils;
+import org.maestro.common.worker.WorkerStateInfo;
+import org.maestro.worker.common.WorkerRuntimeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
+
+import static org.maestro.worker.common.WorkerStateInfoUtil.isCleanExit;
+
+
+/**
+ * An observer for the watchdog that handles the worker shutdown process,
+ * its terminal state and symlink creation on the log directory
+ */
+public class WorkerShutdownObserver implements WatchdogObserver {
+    private static final Logger logger = LoggerFactory.getLogger(WorkerShutdownObserver.class);
+    private static final AbstractConfiguration config = ConfigurationWrapper.getConfig();
+    private static final long TIMEOUT_STOP_WORKER_MILLIS;
+
+    private final File logDir;
+    private final MaestroReceiverClient client;
+
+    static {
+        TIMEOUT_STOP_WORKER_MILLIS = config.getLong("maestro.worker.stop.timeout", 1000);
+    }
+
+    public WorkerShutdownObserver(final File logDir, final MaestroReceiverClient client) {
+        this.logDir = logDir;
+        this.client = client;
+    }
+
+    private static void finishWorkers(final WorkerRuntimeInfo workerRuntimeInfo) {
+        try {
+            logger.debug("Waiting for worker thread {}", workerRuntimeInfo.thread.getId());
+            workerRuntimeInfo.thread.join(TIMEOUT_STOP_WORKER_MILLIS);
+        } catch (InterruptedException e) {
+            //no op, just retry
+        } finally {
+            if (workerRuntimeInfo.thread.isAlive()) {
+                logger.debug("Worker thread {} is still alive", workerRuntimeInfo.thread.getId());
+            }
+        }
+    }
+
+
+    private static long awaitWorkers(long startWaitingWorkersEpochMillis, final List<WorkerRuntimeInfo> workers) {
+        if (workers.isEmpty()) {
+            return 0;
+        }
+
+        int runningCount = workers.size();
+        final long deadLine = startWaitingWorkersEpochMillis + (runningCount * TIMEOUT_STOP_WORKER_MILLIS * 2);
+
+        // workers are being stopped, just need to check if they have finished their jobs
+        long activeThreads = runningCount;
+        while (activeThreads > 0 && System.currentTimeMillis() < deadLine) {
+            workers.stream()
+                    .filter(workerRuntimeInfo -> workerRuntimeInfo.thread.isAlive())
+                    .parallel()
+                    .forEach(workerRuntimeInfo -> finishWorkers(workerRuntimeInfo));
+
+            activeThreads = workers.stream()
+                    .filter(workerRuntimeInfo -> workerRuntimeInfo.thread.isAlive())
+                    .count();
+
+            logger.info("There are {} workers threads still alive", activeThreads);
+        }
+
+        return activeThreads;
+    }
+
+    private void sendTestNotification(boolean failed, String exceptionMessage) {
+
+        if (failed) {
+            if (exceptionMessage != null) {
+                client.notifyFailure(exceptionMessage);
+            }
+            else {
+                client.notifyFailure("Unhandled worker error");
+            }
+        }
+        else {
+            client.notifySuccess("Test completed successfully");
+        }
+    }
+
+    @Override
+    public boolean onStop(final List<WorkerRuntimeInfo> workers) {
+        boolean failed = false;
+        String exceptionMessage = null;
+
+        try {
+            final long startWaitingWorkers = System.currentTimeMillis();
+            if (awaitWorkers(startWaitingWorkers, workers) > 0) {
+                logger.warn("The writer will be forced to stop with alive workers");
+            }
+
+            for (WorkerRuntimeInfo ri : workers) {
+                WorkerStateInfo wsi = ri.worker.getWorkerState();
+
+                if (ri.thread != null && ri.thread.isAlive()) {
+                    logger.warn("Worker {} is reportedly still alive", ri.thread.getId());
+                    ri.thread.interrupt();
+                }
+
+                if (!isCleanExit(wsi)) {
+                    failed = true;
+                    exceptionMessage = Objects.requireNonNull(wsi.getException()).getMessage();
+
+                    break;
+                }
+            }
+        }
+        finally {
+            TestLogUtils.createSymlinks(logDir, failed);
+
+            sendTestNotification(failed, exceptionMessage);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Rework the worker code so that a drain operation is executed after the
test is complete. As part of the implementation, all the post-processing
code that was executed on test completion was refactored to implement
the observer pattern, thus allowing for easier cascading of container
status changes.

Implements #108 .