### PR TITLE
FIX: whitelist InterruptedExceptions thrown by Qpid JMS

### DIFF
--- a/maestro-worker/src/main/resources/config/maestro-worker.properties
+++ b/maestro-worker/src/main/resources/config/maestro-worker.properties
@@ -57,3 +57,7 @@
 # for the drain to run and clean the queues after the test is completed. The total allowed time may be slightly
 # bigger than this to account for all the observers to finish
 # worker.observer.deadline.secs=45
+
+
+# Whether to fail when the sender is blocked in AMQP (ie.: waiting for credits).
+# worker.protocol.amqp10.block.is.failure=false


### PR DESCRIPTION
Proposed fix for issue #141.

Not to be merged yet. Waiting for more tests.