### PR TITLE
FIX: tries to stop the workers asynchronously

### DIFF
--- a/maestro-tests/src/main/java/org/maestro/tests/AbstractTestExecutor.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/AbstractTestExecutor.java
@@ -30,6 +30,7 @@ import org.maestro.common.client.notes.MaestroNote;
 import org.maestro.common.client.notes.TestExecutionInfo;
 import org.maestro.common.client.notes.WorkerStartOptions;
 import org.maestro.common.exceptions.MaestroConnectionException;
+import org.maestro.common.exceptions.MaestroException;
 import org.maestro.common.exceptions.TryAgainException;
 import org.maestro.tests.cluster.DistributionStrategy;
 import org.maestro.tests.utils.CompletionTime;
@@ -176,7 +177,7 @@ public abstract class AbstractTestExecutor implements TestExecutor {
 
     private void checkReplies(List<? extends MaestroNote> replies) {
         if (replies.size() == 0) {
-            logger.warn("Not enough replies for the stop command requests on the test cluster");
+            logger.warn("Not enough replies for the stop command request on the test cluster (can be ignored)");
         }
 
         for (MaestroNote reply : replies) {
@@ -326,6 +327,22 @@ public abstract class AbstractTestExecutor implements TestExecutor {
             logger.error("Error checking the draining status: {}", e.getMessage(), e);
         } catch (TimeoutException e) {
             logger.warn("Did not receive a drain response within {} seconds", drainDeadline);
+        }
+    }
+
+
+    protected void forceStop(final DistributionStrategy distributionStrategy) {
+        logger.info("Force stopping Maestro services");
+        try {
+            stopServices(distributionStrategy);
+        }
+        catch (MaestroException e) {
+            if (e.getCause() instanceof TimeoutException) {
+                logger.warn("Timed out waiting for a stop response");
+            }
+            else {
+                logger.warn(e.getMessage());
+            }
         }
     }
 }

--- a/maestro-tests/src/main/java/org/maestro/tests/AbstractTestExecutor.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/AbstractTestExecutor.java
@@ -176,7 +176,7 @@ public abstract class AbstractTestExecutor implements TestExecutor {
 
     private void checkReplies(List<? extends MaestroNote> replies) {
         if (replies.size() == 0) {
-            logger.error("Not enough replies when trying to execute a command on the test cluster");
+            logger.warn("Not enough replies for the stop command requests on the test cluster");
         }
 
         for (MaestroNote reply : replies) {
@@ -231,9 +231,10 @@ public abstract class AbstractTestExecutor implements TestExecutor {
             stopWorkerFuture.thenAccept(this::checkReplies);
 
             futures.add(stopWorkerFuture);
-
-            futures.forEach(this::verifyStopCommand);
         }
+
+        // This is only used for logging when level == trace
+        futures.forEach(this::verifyStopCommand);
     }
 
 
@@ -249,11 +250,13 @@ public abstract class AbstractTestExecutor implements TestExecutor {
             logger.warn("While stopping the peers: {}", e.getMessage(), e);
         }
 
-        try {
-            exec(maestro::stopInspector, MaestroTopics.peerTopic(Role.INSPECTOR));
-        }
-        catch (NotEnoughRepliesException e) {
-            logger.warn("While stopping the inspector: {}", e.getMessage());
+
+        if (hasInspector) {
+            try {
+                exec(maestro::stopInspector, MaestroTopics.peerTopic(Role.INSPECTOR));
+            } catch (NotEnoughRepliesException e) {
+                logger.warn("While stopping the inspector: {}", e.getMessage());
+            }
         }
     }
 

--- a/maestro-tests/src/main/java/org/maestro/tests/incremental/IncrementalTestProfile.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/incremental/IncrementalTestProfile.java
@@ -155,7 +155,7 @@ public class IncrementalTestProfile extends AbstractTestProfile {
             }
         }
 
-        logger.info("Set target rate to {}", rate);
+        logger.info("Increased target rate to {}", rate);
     }
 
     @Override

--- a/maestro-tests/src/main/java/org/maestro/tests/rate/AbstractFixedRateExecutor.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/rate/AbstractFixedRateExecutor.java
@@ -89,6 +89,10 @@ public abstract class AbstractFixedRateExecutor extends AbstractTestExecutor {
 
                 XUnitGenerator.generate(testExecutionInfo.getTest(), results, start);
 
+                if (results.size() != numPeers) {
+                    forceStop(distributionStrategy);
+                }
+
                 return failures.get();
             }
             finally {
@@ -99,9 +103,11 @@ public abstract class AbstractFixedRateExecutor extends AbstractTestExecutor {
         }
         catch (TimeoutException te) {
             logger.warn("Timed out waiting for the test notifications");
+            forceStop(distributionStrategy);
         }
         catch (Exception e) {
             logger.error("Error: {}", e.getMessage(), e);
+            forceStop(distributionStrategy);
         }
         finally {
             reset();
@@ -149,21 +155,7 @@ public abstract class AbstractFixedRateExecutor extends AbstractTestExecutor {
 
         testStop();
 
-        logger.info("Stopping Maestro services");
-        try {
-            stopServices(distributionStrategy);
-        }
-        catch (MaestroException e) {
-            if (e.getCause() instanceof TimeoutException) {
-                logger.warn("Timed out waiting for a stop response");
-            }
-            else {
-                logger.warn(e.getMessage(), e);
-            }
-        }
-        finally {
-            distributionStrategy.reset();
-        }
+        distributionStrategy.reset();
     }
 
     protected abstract String phaseName();
@@ -179,4 +171,7 @@ public abstract class AbstractFixedRateExecutor extends AbstractTestExecutor {
     public FixedRateTestProfile getTestProfile() {
         return testProfile;
     }
+
+
+
 }

--- a/maestro-tests/src/main/java/org/maestro/tests/rate/AbstractFixedRateExecutor.java
+++ b/maestro-tests/src/main/java/org/maestro/tests/rate/AbstractFixedRateExecutor.java
@@ -139,6 +139,7 @@ public abstract class AbstractFixedRateExecutor extends AbstractTestExecutor {
         return true;
     }
 
+    @Override
     public void stopServices() {
         if (!isRunning()) {
             logger.trace("Not stopping the services because the test is not running");

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/ConcurrentWorkerManager.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/ConcurrentWorkerManager.java
@@ -201,7 +201,7 @@ public class ConcurrentWorkerManager extends MaestroWorkerManager implements Mae
     public void handle(Halt note) {
         logger.debug("Halt request received");
 
-        asyncStop(note);
+        asyncStop();
         setRunning(false);
     }
 
@@ -252,7 +252,7 @@ public class ConcurrentWorkerManager extends MaestroWorkerManager implements Mae
         super.handle(note);
 
         logger.debug("Stopping test execution after a peer reported a test failure");
-        asyncStop(note);
+        asyncStop();
     }
 
     @Override
@@ -260,7 +260,7 @@ public class ConcurrentWorkerManager extends MaestroWorkerManager implements Mae
         super.handle(note);
 
         logger.debug("Stopping test execution after a peer reported a test success");
-        asyncStop(note);
+        asyncStop();
     }
 
     @Override
@@ -362,17 +362,22 @@ public class ConcurrentWorkerManager extends MaestroWorkerManager implements Mae
         logger.info("Stop worker request received");
 
         getClient().replyOk(note);
-        asyncStop(note);
+        asyncStop();
     }
 
-    private void asyncStop(final MaestroNote note) {
+    private void asyncStop() {
         if (container.getWorkerContainerState() == WorkerContainer.WorkerContainerState.STARTED) {
-            stopped = stopExecutor.submit(() -> { container.stop(); return true; });
-            logger.info("Completed stopping the workers");
+            stopped = stopExecutor.submit(() -> doWorkerContainerStop());
         }
         else {
             logger.info("The worker container is not running at the moment therefore the stop call is ignored");
         }
+    }
+
+    private Boolean doWorkerContainerStop() {
+        container.stop();
+        logger.info("Completed stopping the workers");
+        return true;
     }
 
 

--- a/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/WorkerShutdownObserver.java
+++ b/maestro-workers/maestro-worker-common/src/main/java/org/maestro/worker/common/watchdog/WorkerShutdownObserver.java
@@ -59,8 +59,8 @@ public class WorkerShutdownObserver implements WatchdogObserver {
             else {
                 exceptionMessage = exception.getMessage();
                 if (exceptionMessage == null) {
-                    logger.warn("The worked supposedly with {}, but no message was provided", exception.getClass(),
-                            exception);
+                    logger.warn("The worked supposedly failed with {}, but no message was provided",
+                            exception.getClass(), exception);
                     exceptionMessage = String.format("Worker failed with %s but no exception was provided",
                             exception.getClass());
                 }


### PR DESCRIPTION
The idea is to prevent blocking the manager while the workers are stopping. This is a tentative fix for issue #138 

Not to be merged yet. Waiting for more tests.